### PR TITLE
refactor!: move to subcommand-based CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,4 +36,3 @@ plex-footage-sorter SERIESNAME
 We number parts consecutively for a single day.
 If there are more videos for that day that are not in the folder, the part numbering will be wrong.
 We might fix this at a later date.
-s

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -3,4 +3,4 @@
 """Initialiser to make plex_footage_sorter accessible externally."""
 
 # Version number, automatically updated by semantic-release
-__version__ = "1.2.0"
+__version__ = "2.0.0"

--- a/src/plex_footage_sorter/_sort_dated_footage_as_date_series.py
+++ b/src/plex_footage_sorter/_sort_dated_footage_as_date_series.py
@@ -1,0 +1,101 @@
+# Copyright (c) 2023 Benjamin Mummery
+
+"""Process android phone footage default names into plex-friendly filename."""
+
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import Optional
+
+
+def _discover_files(directory: Path, recursive: bool = False) -> dict:
+    """Find files that match the format we want to convert.
+
+    Args:
+        directory (Path): The directory to be searched.
+        recursive (bool, optional): If True, subdirectories will be searched. If false,
+            only the specified directory will be searched. Defaults to False.
+
+    Returns:
+        dict: A ampping of datetime date objects to file paths, where the date is
+            derived from the file name.
+    """
+
+    print(f"Discovering files in {directory}", end="")
+    if recursive:
+        print(" and subdirectories", end="")
+
+    days: dict = {}
+    if recursive:
+        files = [os.path.join(dp, f) for dp, _, fn in os.walk(directory) for f in fn]
+    else:
+        files = os.listdir(directory)
+
+    for file in files:
+        _, filename = os.path.split(file)
+
+        try:
+            if (
+                date := datetime.strptime(
+                    os.path.splitext(filename)[0], "%Y%m%d_%H%M%S"
+                ).date()
+            ) not in days:
+                days[date] = [file]
+            else:
+                days[date].append(file)
+        except ValueError:
+            continue
+    return days
+
+
+def _rename(
+    filepath: Path, series_title: str, day: datetime, part: Optional[int] = None
+):
+    """Generate a new name and rename the specified file.
+
+    Args:
+        filepath (Path): The file to be renamed.
+        series_title (str): The series that this file should be part of.
+        day (datetime): The date on which the file was created.
+        part (Optional[int], optional): If specified, renames the files as part of a
+            multi-file episode for this day. Defaults to None.
+
+    Returns:
+        str: _description_
+    """
+    dir, _ = os.path.split(filepath)
+
+    new_name = f"{series_title} - " f"{day.year}-{day.month:02d}-{day.day:02d}"
+    if part is not None:
+        new_name += f" - Part{part}"
+    new_name += os.path.splitext(filepath)[1]
+
+    os.rename(
+        filepath,
+        os.path.join(dir, new_name),
+    )
+    print(f"  {filepath} --> {new_name}")
+
+
+def main(directory: Path, series_title: str, recursive: bool = False):
+    """Find and rename matching files.
+
+    Args:
+        directory (Path): The directory in which to look for renamable files.
+        series_title (str): The series to which the files should belong.
+        recursive (bool, optional): If True, search subdirectories of the specified
+            directory. Defaults to False.
+    """
+
+    if len(days := _discover_files(directory, recursive)) == 0:
+        print("No files to rename, exiting.")
+        return
+
+    print("\nRenaming files:")
+    for day in days:
+        if len(files := days[day]) == 1:
+            _rename(files[0], series_title, day)
+        else:
+            for i, file in enumerate(sorted(files)):
+                _rename(file, series_title, day, part=i + 1)
+    return

--- a/src/plex_footage_sorter/entry.py
+++ b/src/plex_footage_sorter/entry.py
@@ -1,10 +1,11 @@
 # Copyright (c) 2023 Benjamin Mummery
 
-"""Process android phone footage default names into plex-friendly filename."""
+"""Rename and move files to conform to Plex conventions."""
 
 import argparse
 import os
-from datetime import datetime
+
+from . import _sort_dated_footage_as_date_series
 
 
 def main():
@@ -26,60 +27,9 @@ def main():
     )
     args = parser.parse_args()
 
-    print(f"Discovering files in {os.getcwd()}", end="")
-    if args.recursive:
-        print(" and subdirectories", end="")
-
-    days: dict = {}
-    if args.recursive:
-        files = [os.path.join(dp, f) for dp, _, fn in os.walk(os.getcwd()) for f in fn]
-    else:
-        files = os.listdir()
-
-    for file in files:
-        print(".", end="")
-        _, filename = os.path.split(file)
-
-        try:
-            if (
-                date := datetime.strptime(
-                    os.path.splitext(filename)[0], "%Y%m%d_%H%M%S"
-                ).date()
-            ) not in days:
-                days[date] = [file]
-            else:
-                days[date].append(file)
-        except ValueError:
-            continue
-
-    if len(days) == 0:
-        print("No files to rename, exiting.")
-        return
-
-    print("\nRenaming files:")
-    for day in days:
-        if len(files := days[day]) == 1:
-            dir, _ = os.path.split(files[0])
-            new_name = (
-                f"{args.title} - "
-                f"{day.year}-{day.month:02d}-{day.day:02d}"
-                f"{os.path.splitext(files[0])[1]}"
-            )
-            os.rename(
-                files[0],
-                os.path.join(dir, new_name),
-            )
-            print(f"  {file} --> {new_name}")
-        else:
-            for i, file in enumerate(sorted(files)):
-                dir, _ = os.path.split(file)
-                new_name = (
-                    f"{args.title} - "
-                    f"{day.year}-{day.month:02d}-{day.day:02d} - Part{i+1}"
-                    f"{os.path.splitext(file)[1]}"
-                )
-                os.rename(file, os.path.join(dir, new_name))
-                print(f"  {file} --> {new_name}")
+    return _sort_dated_footage_as_date_series.main(
+        os.getcwd(), args.title, recursive=args.recursive
+    )
 
 
 if __name__ == "__main__":

--- a/src/plex_footage_sorter/entry.py
+++ b/src/plex_footage_sorter/entry.py
@@ -13,12 +13,15 @@ def main():
 
     # Parse args
     parser = argparse.ArgumentParser()
-    parser.add_argument(
+
+    subparsers = parser.add_subparsers(required=True)
+    parser_date_based = subparsers.add_parser("date-based")
+    parser_date_based.add_argument(
         "title",
         type=str,
         help="A custom name to be attached to the start of the new file names.",
     )
-    parser.add_argument(
+    parser_date_based.add_argument(
         "-r",
         "--recursive",
         action="store_true",

--- a/tests/test_integration_sort_dated_footage.py
+++ b/tests/test_integration_sort_dated_footage.py
@@ -13,7 +13,7 @@ class TestNullCases:
     @staticmethod
     def test_no_files(tmp_path: Path, cwd, mocker: MockerFixture):
         # GIVEN
-        mocker.patch("sys.argv", ["stub_name", "stub title"])
+        mocker.patch("sys.argv", ["stub_name", "date-based", "stub title"])
 
         # WHEN
         with cwd(tmp_path):
@@ -28,7 +28,7 @@ class TestNullCases:
         subdir = "subdir"
         (tmp_path / subdir).mkdir()
         (filepath := tmp_path / subdir / filename).write_text("<sentinel>")
-        mocker.patch("sys.argv", ["stub_name", "stub title"])
+        mocker.patch("sys.argv", ["stub_name", "date-based", "stub title"])
         assert filepath.is_file()
 
         # WHEN
@@ -49,7 +49,7 @@ class TestFlatDir:
         # GIVEN
         filename = "20220202_222222.mp4"
         (tmp_path / filename).write_text("<sentinel>")
-        args = ["stub_name", custom_name]
+        args = ["stub_name", "date-based", custom_name]
         if recursion_arg is not None:
             args.append(recursion_arg)
         mocker.patch("sys.argv", args)
@@ -69,7 +69,7 @@ class TestFlatDir:
         # GIVEN
         for i, file in enumerate(["20220202_222222.mp4", "20220202_222223.mp4"]):
             (tmp_path / file).write_text(f"<{i} sentinel>")
-        args = ["stub_name", custom_name]
+        args = ["stub_name", "date-based", custom_name]
         if recursion_arg is not None:
             args.append(recursion_arg)
         mocker.patch("sys.argv", args)
@@ -99,7 +99,7 @@ class TestFlatDir:
             "not_a_matching_file.mp4",
         ]:
             (tmp_path / file).write_text("")
-        args = ["stub_name", custom_name]
+        args = ["stub_name", "date-based", custom_name]
         if recursion_arg is not None:
             args.append(recursion_arg)
         mocker.patch("sys.argv", args)
@@ -135,7 +135,7 @@ class TestFlatDir:
         ]
         for file in files:
             (tmp_path / file).write_text("")
-        args = ["stub_name", custom_name]
+        args = ["stub_name", "date-based", custom_name]
         if recursion_arg is not None:
             args.append(recursion_arg)
         mocker.patch("sys.argv", args)
@@ -163,7 +163,9 @@ class TestSubDirs:
         subdir = "subdir"
         (tmp_path / subdir).mkdir()
         (tmp_path / subdir / filename).write_text("<sentinel>")
-        mocker.patch("sys.argv", ["stub_name", custom_name, recursion_arg])
+        mocker.patch(
+            "sys.argv", ["stub_name", "date-based", custom_name, recursion_arg]
+        )
 
         # WHEN
         with cwd(tmp_path):

--- a/tests/test_system.py
+++ b/tests/test_system.py
@@ -9,13 +9,14 @@ class TestSetup:
     @staticmethod
     def test_install(virtualenv, tmp_path):
         virtualenv.run(f"python -m pip install {os.getcwd()}")
-        virtualenv.run(f"cd {tmp_path} && plex-footage-sorter stub_title")
+        virtualenv.run(f"cd {tmp_path} && plex-footage-sorter date-based stub_title")
 
 
 @pytest.mark.parametrize("custom_name", ["'Training Videos'"])
 class TestRun:
     @staticmethod
     def test_flat_folder(virtualenv, tmp_path, custom_name):
+        # GIVEN
         infiles = ["20220202_222222.mp4", "20220203_222222.mp4", "20220203_222223.mp4"]
         outfiles = [
             "Training Videos - 2022-02-02.mp4",
@@ -25,7 +26,9 @@ class TestRun:
         for file in infiles:
             (tmp_path / file).write_text("")
 
+        # WHEN
         virtualenv.run(f"python -m pip install {os.getcwd()}")
-        virtualenv.run(f"cd {tmp_path} && plex-footage-sorter {custom_name}")
+        virtualenv.run(f"cd {tmp_path} && plex-footage-sorter date-based {custom_name}")
 
+        # THEN
         assert set(os.listdir(tmp_path)) == set(outfiles)

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -11,7 +11,7 @@ class TestNullCases:  # TODO: remove this as soon as we have additional units to
     @staticmethod
     def test_no_files(tmp_path: Path, cwd, mocker: MockerFixture):
         # GIVEN
-        mocker.patch("sys.argv", ["stub_name", "stub title"])
+        mocker.patch("sys.argv", ["stub_name", "date-based", "stub title"])
 
         # WHEN
         with cwd(tmp_path):


### PR DESCRIPTION
BREAKING CHANGE: `date-based` must now be specified when calling `plex-footage-sorter` in order to access the previous default behaviour